### PR TITLE
Feat/degree proof nullifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,6 +1366,7 @@ dependencies = [
  "babyjubjub-rs",
  "bincode",
  "dotenv",
+ "ff",
  "futures",
  "grapevine_circuits",
  "grapevine_common",

--- a/crates/grapevine_common/src/account.rs
+++ b/crates/grapevine_common/src/account.rs
@@ -265,17 +265,15 @@ impl GrapevineAccount {
     ) -> NewRelationshipRequest {
         // generate a nullifier for relationship
         let (nullifier, encrypted_nullifier_secret) = self.generate_nullifier();
-        // encrypt the auth signature with the target pubkey
-        let encrypted_auth_signature = self.generate_auth_signature(pubkey.clone(), nullifier);
+        // encrypt the auth signature and nullifier with the target pubkey
+        let encrypted_auth_secret = self.generate_auth_signature(pubkey.clone(), nullifier);
 
-        let encrypted_nullifier: [u8; 48] = [0u8; 48]; // TODO: Encrypt nullifier
-                                                       // return the New Relationship http request struct
         NewRelationshipRequest {
-            encrypted_nullifier: encrypted_nullifier,
             encrypted_nullifier_secret: encrypted_nullifier_secret,
             to: username.clone(),
-            ephemeral_key: encrypted_auth_signature.ephemeral_key,
-            encrypted_auth_signature: encrypted_auth_signature.ciphertext,
+            ephemeral_key: encrypted_auth_secret.ephemeral_key,
+            encrypted_auth_signature: encrypted_auth_secret.signature_ciphertext,
+            encrypted_nullifier: encrypted_auth_secret.nullifier_ciphertext,
         }
     }
 

--- a/crates/grapevine_common/src/auth_signature.rs
+++ b/crates/grapevine_common/src/auth_signature.rs
@@ -17,9 +17,9 @@ pub struct AuthSignatureEncrypted {
     pub recipient: [u8; 32],
     pub ephemeral_key: [u8; 32],
     #[serde(with = "serde_bytes")]
-    pub nullifier: [u8; 48],
+    pub nullifier_ciphertext: [u8; 48],
     #[serde(with = "serde_bytes")]
-    pub ciphertext: [u8; 80],
+    pub signature_ciphertext: [u8; 80],
 }
 
 /**
@@ -82,7 +82,7 @@ impl AuthSignatureEncryptedUser for AuthSignatureEncrypted {
         let plaintext = signature.compress();
         let mut sig_buf = [0u8; 80];
         sig_buf[..plaintext.len()].copy_from_slice(&plaintext);
-        let ciphertext: [u8; 80] = Aes128CbcEnc::new(aes_key[..].into(), aes_iv[..].into())
+        let signature_ciphertext: [u8; 80] = Aes128CbcEnc::new(aes_key[..].into(), aes_iv[..].into())
             .encrypt_padded_mut::<Pkcs7>(&mut sig_buf, plaintext.len())
             .unwrap()
             .try_into()
@@ -90,7 +90,7 @@ impl AuthSignatureEncryptedUser for AuthSignatureEncrypted {
 
         let mut null_buf = [0u8; 48];
         null_buf[..nullifier_bytes.len()].copy_from_slice(&nullifier_bytes);
-        let encrypted_nullifier: [u8; 48] =
+        let nullifier_ciphertext: [u8; 48] =
             Aes128CbcEnc::new(aes_key[..].into(), aes_iv[..].into())
                 .encrypt_padded_mut::<Pkcs7>(&mut null_buf, nullifier_bytes.len())
                 .unwrap()
@@ -102,8 +102,8 @@ impl AuthSignatureEncryptedUser for AuthSignatureEncrypted {
             username,
             recipient: recipient.compress(),
             ephemeral_key: ephm_pk,
-            ciphertext: ciphertext,
-            nullifier: encrypted_nullifier,
+            signature_ciphertext,
+            nullifier_ciphertext,
         }
     }
 
@@ -113,7 +113,7 @@ impl AuthSignatureEncryptedUser for AuthSignatureEncrypted {
         let (aes_key, aes_iv) = gen_aes_key(recipient, ephm_pk);
 
         // decrypt the auth signature
-        let mut sig_buf = self.ciphertext;
+        let mut sig_buf = self.signature_ciphertext;
         let auth_signature: [u8; 64] = Aes128CbcDec::new(aes_key[..].into(), aes_iv[..].into())
             .decrypt_padded_mut::<Pkcs7>(&mut sig_buf)
             .unwrap()
@@ -121,7 +121,7 @@ impl AuthSignatureEncryptedUser for AuthSignatureEncrypted {
             .unwrap();
 
         // decrypt the nullifier
-        let mut null_buf = self.nullifier;
+        let mut null_buf = self.nullifier_ciphertext;
         let nullifier: [u8; 32] = Aes128CbcDec::new(aes_key[..].into(), aes_iv[..].into())
             .decrypt_padded_mut::<Pkcs7>(&mut null_buf)
             .unwrap()

--- a/crates/grapevine_common/src/errors.rs
+++ b/crates/grapevine_common/src/errors.rs
@@ -16,6 +16,7 @@ pub enum GrapevineError {
     RelationshipSenderIsTarget,
     PhraseExists,
     PhraseNotFound,
+    ProofNotFound(String),
     InvalidPhraseHash,
     NonceMismatch(u64, u64),
     MongoError(String),
@@ -81,6 +82,7 @@ impl std::fmt::Display for GrapevineError {
                 write!(f, "This phrase has already added used by another account")
             }
             GrapevineError::PhraseNotFound => write!(f, "Phrase not found"),
+            GrapevineError::ProofNotFound(oid) => write!(f, "Proof '{}' not found", oid),
             GrapevineError::MongoError(msg) => write!(f, "Mongo error: {}", msg),
             GrapevineError::HeaderError(msg) => write!(f, "Bad http header error: `{}`", msg),
             GrapevineError::InvalidPhraseHash => write!(f, "Invalid phrase hash provided"),

--- a/crates/grapevine_common/src/models.rs
+++ b/crates/grapevine_common/src/models.rs
@@ -15,6 +15,14 @@ pub struct GrapevineProof {
     pub inactive: Option<bool>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AvailableProofs {
+    pub id: ObjectId,
+    pub degree: u8,
+    pub scope: String,
+    pub relation: String
+}
+
 // // all data needed from server to prove a degree of separation
 // #[derive(Debug, Serialize, Deserialize, Clone)]
 // pub struct ProvingData {

--- a/crates/grapevine_common/src/models.rs
+++ b/crates/grapevine_common/src/models.rs
@@ -23,6 +23,20 @@ pub struct AvailableProofs {
     pub relation: String
 }
 
+// todo: maybe move this somewhere else? is not used in transport
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DegreeProofValidationData {
+    #[serde(default, with = "serde_bytes")]
+    pub prover_address: [u8; 32],
+    pub prover_oid: ObjectId,
+    #[serde(default, with = "serde_bytes")]
+    pub scope: [u8; 32],
+    pub scope_oid: ObjectId,
+    pub nullifiers: Vec<[u8; 32]>,
+    pub degree: u8,
+    pub inactive: bool
+}
+
 // all data needed from server to prove a degree of separation
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ProvingData {

--- a/crates/grapevine_common/src/models.rs
+++ b/crates/grapevine_common/src/models.rs
@@ -23,21 +23,19 @@ pub struct AvailableProofs {
     pub relation: String
 }
 
-// // all data needed from server to prove a degree of separation
-// #[derive(Debug, Serialize, Deserialize, Clone)]
-// pub struct ProvingData {
-//     pub phrase_index: u32,
-//     #[serde(default, with = "serde_bytes")]
-//     pub phrase_hash: [u8; 32],
-//     pub description: String,
-//     pub degree: u8, // multiply by 2 to get iterations
-//     pub proof: Vec<u8>,
-//     pub username: String,
-//     #[serde(with = "serde_bytes")]
-//     pub ephemeral_key: [u8; 32],
-//     #[serde(with = "serde_bytes")]
-//     pub ciphertext: [u8; 80],
-// }
+// all data needed from server to prove a degree of separation
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ProvingData {
+    #[serde(default, with = "serde_bytes")]
+    pub relation_pubkey: [u8; 32],
+    pub proof: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub ephemeral_key: [u8; 32],
+    #[serde(with = "serde_bytes")]
+    pub signature_ciphertext: [u8; 80],
+    #[serde(with = "serde_bytes")]
+    pub nullifier_ciphertext: [u8; 48],
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Relationship {

--- a/crates/grapevine_server/Cargo.toml
+++ b/crates/grapevine_server/Cargo.toml
@@ -29,6 +29,9 @@ tracing = "0.1.40"
 rocket = { version = "0.5.0", features = ["json", "tls"] }
 futures = "0.3.30"
 
+[dev-dependencies]
+ff.workspace = true
+
 [build-dependencies]
 dotenv.workspace = true
 

--- a/crates/grapevine_server/Cargo.toml
+++ b/crates/grapevine_server/Cargo.toml
@@ -28,8 +28,6 @@ tracing-subscriber = "0.3.17"
 tracing = "0.1.40"
 rocket = { version = "0.5.0", features = ["json", "tls"] }
 futures = "0.3.30"
-
-[dev-dependencies]
 ff.workspace = true
 
 [build-dependencies]

--- a/crates/grapevine_server/src/main.rs
+++ b/crates/grapevine_server/src/main.rs
@@ -120,7 +120,7 @@ mod test_rocket {
         use super::*;
         use grapevine_circuits::{inputs::GrapevineInputs, utils::compress_proof};
         use grapevine_common::{
-            account::GrapevineAccount, http::requests::CreateUserRequest, models::{AvailableProofs, Relationship},
+            account::GrapevineAccount, http::requests::CreateUserRequest, models::{AvailableProofs, ProvingData, Relationship},
             NovaProof,
         };
 
@@ -234,7 +234,7 @@ mod test_rocket {
 
         pub async fn http_get_available_proofs(
             context: &GrapevineTestContext,
-            user: &GrapevineAccount,
+            user: &mut GrapevineAccount,
         ) -> Vec<AvailableProofs> {
             let username = user.username().clone();
             let signature = generate_nonce_signature(user);
@@ -250,6 +250,31 @@ mod test_rocket {
                 .into_json::<Vec<AvailableProofs>>()
                 .await;
 
+            let _ = user.increment_nonce(None);
+            res.unwrap()
+        }
+
+        pub async fn http_get_proving_data(
+            context: &GrapevineTestContext,
+            user: &mut GrapevineAccount,
+            proof: &String
+        ) -> ProvingData {
+            let username = user.username().clone();
+            let signature = generate_nonce_signature(user);
+            let uri = format!("/proof/params/{}", proof);
+
+            // mock transmit the request
+            let res = context
+                .client
+                .get(uri)
+                .header(Header::new("X-Authorization", signature))
+                .header(Header::new("X-Username", username))
+                .dispatch()
+                .await
+                .into_json::<ProvingData>()
+                .await;
+
+            let _ = user.increment_nonce(None);
             res.unwrap()
         }
     }
@@ -381,8 +406,13 @@ mod test_rocket {
 
     #[cfg(test)]
     mod degree_proof_tests {
+        use grapevine_circuits::{inputs::{GrapevineInputs, GrapevineOutputs}, nova::{degree_proof, verify_grapevine_proof}};
+        use grapevine_common::{Fr, auth_signature::AuthSignatureEncryptedUser};
+        use babyjubjub_rs::{decompress_point, decompress_signature};
+        use ff::PrimeField;
+
         use super::*;
-        use crate::test_rocket::test_helper::http_get_available_proofs;
+        use crate::test_rocket::test_helper::*;
 
         #[rocket::async_test]
         pub async fn test_degree_one() {
@@ -397,9 +427,6 @@ mod test_rocket {
             let user_request_b = build_create_user_request(&user_b);
             http_create_user(&context, &user_request_b).await;
 
-            let mut user_c = GrapevineAccount::new("user_c".into());
-            let user_request_c = build_create_user_request(&user_c);
-            http_create_user(&context, &user_request_c).await;
             // establish relationship between users
             let user_a_relationship_request =
                 user_a.new_relationship_request(user_b.username(), &user_b.pubkey());
@@ -407,19 +434,47 @@ mod test_rocket {
             let user_b_relationship_request =
                 user_b.new_relationship_request(user_a.username(), &user_a.pubkey());
             http_add_relationship(&context, &mut user_b, &user_b_relationship_request).await;
-
-            let request =
-                user_a.new_relationship_request(user_c.username(), &user_c.pubkey());
-            http_add_relationship(&context, &mut user_a, &request).await;
-            let request =
-                user_c.new_relationship_request(user_a.username(), &user_a.pubkey());
-            http_add_relationship(&context, &mut user_c, &request).await;
+            
             // retrieve available proofs as user_b
-            let proofs = http_get_available_proofs(&context, &user_b).await;
-            println!("Proofs: {:?}", proofs);
-            let proofs = http_get_available_proofs(&context, &user_a).await;
-            println!("Proofs: {:?}", proofs);
+            let available_proofs = http_get_available_proofs(&context, &mut user_b).await;
+            // retrieve proving data for user_b to prove degree 1 from user_a
+            let oid = available_proofs[0].id.to_string();
+            let degree = available_proofs[0].degree as usize;
+            let proving_data = http_get_proving_data(&context, &mut user_b, &oid).await;
 
+            // decompress the proof
+            let mut proof = decompress_proof(&proving_data.proof[..]);
+            let res = verify_grapevine_proof(&proof, &ARTIFACTS.params, degree).unwrap().0;
+            let outputs = GrapevineOutputs::try_from(res).unwrap();
+            // decrypt the auth secret
+            let auth_secret_encrypted = AuthSignatureEncrypted {
+                username: "".into(),
+                recipient: user_b.pubkey().compress(),
+                ephemeral_key: proving_data.ephemeral_key,
+                signature_ciphertext: proving_data.signature_ciphertext,
+                nullifier_ciphertext: proving_data.nullifier_ciphertext,
+            };
+            let auth_secret = auth_secret_encrypted.decrypt(user_b.private_key());
+            // build the inputs for the degree proof
+            let auth_signature = decompress_signature(&auth_secret.auth_signature).unwrap();
+            let relation_pubkey = decompress_point(proving_data.relation_pubkey).unwrap();
+            let relation_nullifier = Fr::from_repr(auth_secret.nullifier).unwrap();
+            let inputs = GrapevineInputs::degree_step(
+                &user_b.private_key(),
+                &relation_pubkey,
+                &relation_nullifier,
+                &outputs.scope,
+                &auth_signature
+            );
+            
+            // user_b proves degree 1 separation from user_a
+            degree_proof(&ARTIFACTS, &inputs, &mut proof, &outputs.try_into().unwrap()).unwrap();
+
+            // verify proof
+            let res = verify_grapevine_proof(&proof, &ARTIFACTS.params, degree + 1).unwrap().0;
+            let output = GrapevineOutputs::try_from(res).unwrap();
+
+            println!("Verified: {:#?}", output);
         }
     }
     

--- a/crates/grapevine_server/src/mongo.rs
+++ b/crates/grapevine_server/src/mongo.rs
@@ -1245,7 +1245,7 @@ impl GrapevineDB {
             doc! {
                 "$lookup": {
                     "from": "users",
-                    "let": { "username": "user_a" },
+                    "let": { "username": username },
                     "pipeline": [
                         {"$match": { "$expr": { "$eq": [ "$username", "$$username" ] }}},
                         { "$project": { "_id": 1 }}
@@ -1259,7 +1259,7 @@ impl GrapevineDB {
             doc! {
                 "$lookup": {
                     "from": "relationships",
-                    "let": { "sender": "$relation", "recipient": "$user_id" },
+                    "let": { "sender": "$user_id", "recipient": "$relation" },
                     "pipeline": [
                         {
                             "$match": {
@@ -1298,7 +1298,7 @@ impl GrapevineDB {
         ];
 
         // Get the proving data
-        let mut cursor = self.users.aggregate(pipeline, None).await.unwrap();
+        let mut cursor = self.proofs.aggregate(pipeline, None).await.unwrap();
         if let Some(result) = cursor.next().await {
             match result {
                 Ok(document) => {
@@ -1331,9 +1331,13 @@ impl GrapevineDB {
                         nullifier_ciphertext: encrypted_nullifier
                     })
                 }
-                Err(_) => None,
+                Err(_) => {
+                    println!("Error");
+                    None
+                }
             }
         } else {
+            println!("No doc found");
             None
         }
     }

--- a/crates/grapevine_server/src/mongo.rs
+++ b/crates/grapevine_server/src/mongo.rs
@@ -2,7 +2,9 @@ use futures::stream::StreamExt;
 use futures::TryStreamExt;
 use grapevine_common::errors::GrapevineError;
 use grapevine_common::http::responses::DegreeData;
-use grapevine_common::models::{AvailableProofs, GrapevineProof, ProvingData, Relationship, User};
+use grapevine_common::models::{
+    AvailableProofs, DegreeProofValidationData, GrapevineProof, ProvingData, Relationship, User,
+};
 use mongodb::bson::{self, doc, oid::ObjectId, Binary, Bson};
 use mongodb::options::{ClientOptions, FindOneOptions, FindOptions, ServerApi, ServerApiVersion};
 use mongodb::{Client, Collection};
@@ -148,20 +150,97 @@ impl GrapevineDB {
             .unwrap()
     }
 
-    // pub async fn get_pubkey(&self, username: String) -> Option<[u8; 32]> {
-    //     let filter = doc! { "username": username };
-    //     let projection = doc! { "pubkey": 1 };
-    //     let find_options = FindOneOptions::builder().projection(projection).build();
-    //     let user = self
-    //         .users
-    //         .find_one(filter, Some(find_options))
-    //         .await
-    //         .unwrap();
-    //     match user {
-    //         Some(user) => Some(user.pubkey.unwrap()),
-    //         None => None,
-    //     }
-    // }
+    /**
+     * Returns all the information needed for validating a degree proof
+     * @dev returns 404 if the proof does not exist
+     *
+     * @param username - the username of the requesting user
+     * @param proof - the object id of the degree proof
+     *
+     * @returns: all data used to validate proof being added to chain if proof found, or None
+     */
+    pub async fn get_degree_data(
+        &self,
+        username: &String,
+        proof: &ObjectId,
+    ) -> Option<DegreeProofValidationData> {
+        // find degree chains they are not a part of
+        let pipeline = vec![
+            // 1. Look up the address of the proving user
+            doc! { "$match": { "username": username } },
+            doc! { "$project": { "address": 1, "_id": 1 } },
+            // 2. Look up the matching proof document
+            doc! { "$lookup": {
+                "from": "proofs",
+                "pipeline": [
+                    doc! { "$match": { "$expr": { "$eq": ["$_id", proof] } } },
+                    doc! { "$project": { "scope": 1, "degree": 1, "nullifiers": 1, "inactive": 1, "_id": 0 } }
+                ],
+                "as": "proofDoc"
+            }},
+            doc! { "$unwind": "$proofDoc" },
+            // 3. Look up the scope address given in the proof document
+            doc! { "$lookup": {
+                "from": "users",
+                "localField": "proofDoc.scope",
+                "foreignField": "_id",
+                "pipeline": [
+                    doc! { "$project": { "address": 1, "_id": 1 } }
+                ],
+                "as": "scopeAddress"
+            }},
+            doc! { "$unwind": "$scopeAddress" },
+            // 4. Project out unnecessary data and reshape according to returned values
+            doc! { "$project": {
+                "_id": 0,
+                "prover_oid": "$_id",
+                "prover_address": "$address",
+                "degree": "$proofDoc.degree",
+                "nullifiers": "$proofDoc.nullifiers",
+                "inactive": "$proofDoc.inactive",
+                "scope": "$scopeAddress.address",
+                "scope_oid": "$scopeAddress._id"
+            }},
+        ];
+        // get the OID's of degree proofs the user can build from
+        let mut cursor = self.users.aggregate(pipeline, None).await.unwrap();
+        if let Some(result) = cursor.next().await {
+            match result {
+                Ok(document) => {
+                    let validation_data: DegreeProofValidationData =
+                        bson::from_bson(bson::Bson::Document(document)).unwrap();
+                    Some(validation_data)
+                }
+                Err(e) => {
+                    println!("Error: {}", e);
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    }
+
+    /**
+     * Get the pubkey and the address of a user
+     *
+     * @param username - the username of the user to get the pubkey for
+     * @return - (compressed pubkey, address)
+     */
+    pub async fn get_pubkey(&self, username: &String) -> Option<([u8; 32], [u8; 32])> {
+        let filter = doc! { "username": username };
+        let projection = doc! { "pubkey": 1, "address": 1 };
+        let find_options = FindOneOptions::builder().projection(projection).build();
+        let user = self
+            .users
+            .find_one(filter, Some(find_options))
+            .await
+            .unwrap();
+        match user {
+            Some(user) => Some((user.pubkey.unwrap(), user.address.unwrap())),
+            None => None,
+        }
+    }
 
     pub async fn add_pending_relationship(
         &self,
@@ -620,196 +699,197 @@ impl GrapevineDB {
         }
     }
 
-    // pub async fn add_proof(
-    //     &self,
-    //     user: &ObjectId,
-    //     proof: &DegreeProof,
-    // ) -> Result<ObjectId, GrapevineError> {
-    //     // fetch all proofs preceding this one
-    //     let mut proof_chain: Vec<DegreeProof> = vec![];
-    //     let mut cursor = self
-    //         .degree_proofs
-    //         .aggregate(
-    //             vec![
-    //                 doc! {
-    //                   "$match": {
-    //                     "user": user,
-    //                     "phrase": proof.phrase
-    //                   }
-    //                 },
-    //                 doc! {
-    //                   "$graphLookup": {
-    //                     "from": "degree_proofs",
-    //                     "startWith": "$preceding", // Assuming 'preceding' is a field that points to the parent document
-    //                     "connectFromField": "preceding",
-    //                     "connectToField": "_id",
-    //                     "as": "preceding_chain",
-    //                   }
-    //                 },
-    //                 doc! {
-    //                     "$project": {
-    //                         "_id": 1,
-    //                         "degree": 1,
-    //                         "inactive": 1,
-    //                         "preceding": 1,
-    //                         "proceeding": 1,
-    //                         "preceding_chain": {
-    //                             "$map": {
-    //                                 "input": "$preceding_chain",
-    //                                 "as": "chain",
-    //                                 "in": {
-    //                                     "_id": "$$chain._id",
-    //                                     "degree": "$$chain.degree",
-    //                                     "inactive": "$$chain.inactive",
-    //                                     "preceding": "$$chain.preceding",
-    //                                     "proceeding": "$$chain.proceeding",
-    //                                 }
-    //                             }
-    //                         }
-    //                     }
-    //                 },
-    //             ],
-    //             None,
-    //         )
-    //         .await
-    //         .unwrap();
-    //     while let Some(result) = cursor.next().await {
-    //         match result {
-    //             Ok(document) => {
-    //                 let preceding_chain = document.get("preceding_chain");
-    //                 let mut parsed: Vec<DegreeProof> = vec![];
-    //                 if preceding_chain.is_some() {
-    //                     parsed =
-    //                         bson::from_bson::<Vec<DegreeProof>>(preceding_chain.unwrap().clone())
-    //                             .unwrap();
-    //                 }
-    //                 let base_proof = bson::from_document::<DegreeProof>(document).unwrap();
-    //                 proof_chain.push(base_proof);
-    //                 proof_chain.append(&mut parsed);
-    //             }
-    //             Err(e) => println!("Error: {}", e),
-    //         }
-    //     }
+    pub async fn add_degree_proof(
+        &self,
+        proof: &GrapevineProof,
+    ) -> Result<ObjectId, GrapevineError> {
+        // TODO: Implement proof deactivation
 
-    //     // Sort by degrees
-    //     proof_chain.sort_by(|a, b| b.degree.cmp(&a.degree));
+        // // fetch all proofs preceding this one
+        // let mut proof_chain: Vec<DegreeProof> = vec![];
+        // let mut cursor = self
+        //     .degree_proofs
+        //     .aggregate(
+        //         vec![
+        //             doc! {
+        //               "$match": {
+        //                 "user": user,
+        //                 "phrase": proof.phrase
+        //               }
+        //             },
+        //             doc! {
+        //               "$graphLookup": {
+        //                 "from": "degree_proofs",
+        //                 "startWith": "$preceding", // Assuming 'preceding' is a field that points to the parent document
+        //                 "connectFromField": "preceding",
+        //                 "connectToField": "_id",
+        //                 "as": "preceding_chain",
+        //               }
+        //             },
+        //             doc! {
+        //                 "$project": {
+        //                     "_id": 1,
+        //                     "degree": 1,
+        //                     "inactive": 1,
+        //                     "preceding": 1,
+        //                     "proceeding": 1,
+        //                     "preceding_chain": {
+        //                         "$map": {
+        //                             "input": "$preceding_chain",
+        //                             "as": "chain",
+        //                             "in": {
+        //                                 "_id": "$$chain._id",
+        //                                 "degree": "$$chain.degree",
+        //                                 "inactive": "$$chain.inactive",
+        //                                 "preceding": "$$chain.preceding",
+        //                                 "proceeding": "$$chain.proceeding",
+        //                             }
+        //                         }
+        //                     }
+        //                 }
+        //             },
+        //         ],
+        //         None,
+        //     )
+        //     .await
+        //     .unwrap();
+        // while let Some(result) = cursor.next().await {
+        //     match result {
+        //         Ok(document) => {
+        //             let preceding_chain = document.get("preceding_chain");
+        //             let mut parsed: Vec<DegreeProof> = vec![];
+        //             if preceding_chain.is_some() {
+        //                 parsed =
+        //                     bson::from_bson::<Vec<DegreeProof>>(preceding_chain.unwrap().clone())
+        //                         .unwrap();
+        //             }
+        //             let base_proof = bson::from_document::<DegreeProof>(document).unwrap();
+        //             proof_chain.push(base_proof);
+        //             proof_chain.append(&mut parsed);
+        //         }
+        //         Err(e) => println!("Error: {}", e),
+        //     }
+        // }
 
-    //     let mut delete_entities: Vec<ObjectId> = vec![];
-    //     // Tuple containing object id, inactive status, updated proceeding array
-    //     let mut update_entitity: (ObjectId, bool, ObjectId) =
-    //         (ObjectId::new(), false, ObjectId::new());
+        // // Sort by degrees
+        // proof_chain.sort_by(|a, b| b.degree.cmp(&a.degree));
 
-    //     // There may be multiple delete values but there will always be one update
-    //     let mut index = 0;
+        // let mut delete_entities: Vec<ObjectId> = vec![];
+        // // Tuple containing object id, inactive status, updated proceeding array
+        // let mut update_entitity: (ObjectId, bool, ObjectId) =
+        //     (ObjectId::new(), false, ObjectId::new());
 
-    //     while index < proof_chain.len() {
-    //         let proof = proof_chain.get(index).unwrap();
-    //         let empty_proceeding =
-    //             proof.proceeding.is_none() || proof.proceeding.clone().unwrap().is_empty();
+        // // There may be multiple delete values but there will always be one update
+        // let mut index = 0;
 
-    //         // If proceeding isn't empty on base proof we simply flag it as inactive and exit
-    //         if index == 0 && !empty_proceeding {
-    //             update_entitity.0 = proof.id.unwrap();
-    //             update_entitity.1 = true;
+        // while index < proof_chain.len() {
+        //     let proof = proof_chain.get(index).unwrap();
+        //     let empty_proceeding =
+        //         proof.proceeding.is_none() || proof.proceeding.clone().unwrap().is_empty();
 
-    //             // Make loop exit
-    //             index = proof_chain.len();
-    //         } else {
-    //             if empty_proceeding && (index == 0 || proof.inactive.unwrap()) {
-    //                 delete_entities.push(proof.id.unwrap());
-    //                 // Remove from preceding proof's proceeding vec
-    //                 let next_proof = proof_chain.get(index + 1).unwrap();
-    //                 let mut next_proceeding = next_proof.proceeding.clone().unwrap();
-    //                 let pos = next_proceeding
-    //                     .iter()
-    //                     .position(|&x| x == proof.id.unwrap())
-    //                     .unwrap();
+        //     // If proceeding isn't empty on base proof we simply flag it as inactive and exit
+        //     if index == 0 && !empty_proceeding {
+        //         update_entitity.0 = proof.id.unwrap();
+        //         update_entitity.1 = true;
 
-    //                 update_entitity.0 = next_proof.id.unwrap();
-    //                 update_entitity.2 = next_proceeding.remove(pos);
+        //         // Make loop exit
+        //         index = proof_chain.len();
+        //     } else {
+        //         if empty_proceeding && (index == 0 || proof.inactive.unwrap()) {
+        //             delete_entities.push(proof.id.unwrap());
+        //             // Remove from preceding proof's proceeding vec
+        //             let next_proof = proof_chain.get(index + 1).unwrap();
+        //             let mut next_proceeding = next_proof.proceeding.clone().unwrap();
+        //             let pos = next_proceeding
+        //                 .iter()
+        //                 .position(|&x| x == proof.id.unwrap())
+        //                 .unwrap();
 
-    //                 proof_chain[index + 1].proceeding = Some(next_proceeding);
-    //                 index += 1;
-    //             // When we reach the last inactive proof we can end the loop
-    //             } else {
-    //                 index = proof_chain.len();
-    //             }
-    //         }
-    //     }
+        //             update_entitity.0 = next_proof.id.unwrap();
+        //             update_entitity.2 = next_proceeding.remove(pos);
 
-    //     // Delete documents if not empty
-    //     if !delete_entities.is_empty() {
-    //         let filter = doc! {
-    //             "_id": {"$in": delete_entities} // Match documents whose IDs are in the provided list
-    //         };
-    //         self.degree_proofs
-    //             .delete_many(filter, None)
-    //             .await
-    //             .expect("Error deleting degree proofs");
-    //     }
+        //             proof_chain[index + 1].proceeding = Some(next_proceeding);
+        //             index += 1;
+        //         // When we reach the last inactive proof we can end the loop
+        //         } else {
+        //             index = proof_chain.len();
+        //         }
+        //     }
+        // }
 
-    //     // Update document
-    //     let update_filter = doc! {"_id": update_entitity.0};
-    //     let update;
-    //     if update_entitity.1 {
-    //         update = doc! {"$set": { "inactive": true }};
-    //     } else {
-    //         update = doc! {"$pull": { "proceeding": update_entitity.2 }};
-    //     }
+        // // Delete documents if not empty
+        // if !delete_entities.is_empty() {
+        //     let filter = doc! {
+        //         "_id": {"$in": delete_entities} // Match documents whose IDs are in the provided list
+        //     };
+        //     self.degree_proofs
+        //         .delete_many(filter, None)
+        //         .await
+        //         .expect("Error deleting degree proofs");
+        // }
+
+        // Update document
+        // let update_filter = doc! {"_id": update_entitity.0};
+        // let update;
+        // if update_entitity.1 {
+        //     update = doc! {"$set": { "inactive": true }};
+        // } else {
+        //     update = doc! {"$pull": { "proceeding": update_entitity.2 }};
+        // }
+        // self.degree_proofs
+        //     .update_one(update_filter, update, None)
+        //     .await
+        //     .expect("Error updating degree proof");
+
+        // create new proof document
+        let proof_oid = self
+            .proofs
+            .insert_one(proof, None)
+            .await
+            .unwrap()
+            .inserted_id
+            .as_object_id()
+            .unwrap();
+
+        // // reference this proof in previous proof if not first proof in chain
+        // if proof.preceding.is_some() {
+        //     let query = doc! { "_id": proof.preceding.unwrap() };
+        //     let update = doc! { "$push": { "proceeding": bson::to_bson(&proof_oid).unwrap()} };
+        //     self.degree_proofs
+        //         .update_one(query, update, None)
+        //         .await
+        //         .unwrap();
+        // }
+
+        // // push the proof to the user's list of proofs
+        // let query = doc! { "_id": user };
+        // let update = doc! {"$push": { "degree_proofs": bson::to_bson(&proof_oid).unwrap()}};
+        // self.users
+        //     .update_one(query.clone(), update, None)
+        //     .await
+        //     .unwrap();
+
+        // // If a proof is marked inactive then remove from user's list of degree proofs
+        // if update_entitity.1 {
+        //     let update = doc! { "$pull": { "degree_proofs": update_entitity.0 } };
+        //     self.users.update_one(query, update, None).await.unwrap();
+        // }
+        Ok(proof_oid)
+    }
+
+    // pub async fn get_proof(&self, proof_oid: &ObjectId) -> Option<DegreeProof> {
     //     self.degree_proofs
-    //         .update_one(update_filter, update, None)
-    //         .await
-    //         .expect("Error updating degree proof");
-
-    //     // create new proof document
-    //     let proof_oid = self
-    //         .degree_proofs
-    //         .insert_one(proof, None)
+    //         .find_one(doc! { "_id": proof_oid }, None)
     //         .await
     //         .unwrap()
-    //         .inserted_id
-    //         .as_object_id()
-    //         .unwrap();
-
-    //     // reference this proof in previous proof if not first proof in chain
-    //     if proof.preceding.is_some() {
-    //         let query = doc! { "_id": proof.preceding.unwrap() };
-    //         let update = doc! { "$push": { "proceeding": bson::to_bson(&proof_oid).unwrap()} };
-    //         self.degree_proofs
-    //             .update_one(query, update, None)
-    //             .await
-    //             .unwrap();
-    //     }
-
-    //     // push the proof to the user's list of proofs
-    //     let query = doc! { "_id": user };
-    //     let update = doc! {"$push": { "degree_proofs": bson::to_bson(&proof_oid).unwrap()}};
-    //     self.users
-    //         .update_one(query.clone(), update, None)
-    //         .await
-    //         .unwrap();
-
-    //     // If a proof is marked inactive then remove from user's list of degree proofs
-    //     if update_entitity.1 {
-    //         let update = doc! { "$pull": { "degree_proofs": update_entitity.0 } };
-    //         self.users.update_one(query, update, None).await.unwrap();
-    //     }
-    //     Ok(proof_oid)
     // }
 
-    // // pub async fn get_proof(&self, proof_oid: &ObjectId) -> Option<DegreeProof> {
-    // //     self.degree_proofs
-    // //         .find_one(doc! { "_id": proof_oid }, None)
-    // //         .await
-    // //         .unwrap()
-    // // }
-
-    // // pub async fn remove_user(&self, user: &ObjectId) {
-    // //     self.users
-    // //         .delete_one(doc! { "_id": user }, None)
-    // //         .await
-    // //         .expect("Failed to remove user");
-    // // }
+    // pub async fn remove_user(&self, user: &ObjectId) {
+    //     self.users
+    //         .delete_one(doc! { "_id": user }, None)
+    //         .await
+    //         .expect("Failed to remove user");
+    // }
 
     /**
      * Given a user, find available degrees of separation proofs they can build from
@@ -1322,13 +1402,13 @@ impl GrapevineDB {
                     if let Some(Bson::Binary(binary)) = document.get("encrypted_nullifier") {
                         encrypted_nullifier = binary.bytes.clone().try_into().unwrap();
                     };
-                    
+
                     Some(ProvingData {
                         proof,
                         relation_pubkey,
                         ephemeral_key,
                         signature_ciphertext: encrypted_auth_signature,
-                        nullifier_ciphertext: encrypted_nullifier
+                        nullifier_ciphertext: encrypted_nullifier,
                     })
                 }
                 Err(_) => {

--- a/crates/grapevine_server/src/routes/mod.rs
+++ b/crates/grapevine_server/src/routes/mod.rs
@@ -22,7 +22,7 @@ lazy_static! {
         // proof::degree_proof,
         proof::get_available_proofs,
         // proof::get_phrase_connections,
-        // proof::get_proof_with_params,
+        proof::get_proof_with_params,
         // proof::get_known_phrases,
         // proof::get_phrase
     ];

--- a/crates/grapevine_server/src/routes/mod.rs
+++ b/crates/grapevine_server/src/routes/mod.rs
@@ -19,7 +19,7 @@ lazy_static! {
     ];
     pub(crate) static ref PROOF_ROUTES: Vec<Route> = routes![
         proof::prove_identity,
-        // proof::degree_proof,
+        proof::degree_proof,
         proof::get_available_proofs,
         // proof::get_phrase_connections,
         proof::get_proof_with_params,

--- a/crates/grapevine_server/src/routes/mod.rs
+++ b/crates/grapevine_server/src/routes/mod.rs
@@ -20,7 +20,7 @@ lazy_static! {
     pub(crate) static ref PROOF_ROUTES: Vec<Route> = routes![
         proof::prove_identity,
         // proof::degree_proof,
-        // proof::get_available_proofs,
+        proof::get_available_proofs,
         // proof::get_phrase_connections,
         // proof::get_proof_with_params,
         // proof::get_known_phrases,

--- a/crates/grapevine_server/src/routes/proof.rs
+++ b/crates/grapevine_server/src/routes/proof.rs
@@ -3,7 +3,7 @@ use crate::mongo::GrapevineDB;
 use crate::utils::PUBLIC_PARAMS;
 use crate::{catchers::GrapevineResponse, guards::AuthenticatedUser};
 use grapevine_circuits::{nova::verify_grapevine_proof, utils::decompress_proof, inputs::GrapevineOutputs};
-use grapevine_common::models::AvailableProofs;
+use grapevine_common::models::{AvailableProofs, ProvingData};
 use grapevine_common::{
     Fr, MAX_USERNAME_CHARS,
     http::{
@@ -472,39 +472,39 @@ pub async fn get_available_proofs(
     Ok(Json(db.find_available_degrees(user.0).await))
 }
 
-// /**
-//  * Returns all the information needed to construct a proof of degree of separation from a given user
-//  *
-//  * @param oid - the ObjectID of the proof to retrieve
-//  * @param username - the username to retrieve encrypted auth signature for when proving relationship
-//  * @return - a ProvingData struct containing:
-//  *         * degree: the separation degree of the returned proof
-//  *         * proof: the gzip-compressed fold proof
-//  *         * username: the username of the proof creator
-//  *         * ephemeral_key: the ephemeral pubkey that can be combined with the requesting user's
-//  *           private key to derive returned proof creator's auth signature decryption key
-//  *         * ciphertext: the encrypted auth signature
-//  * @return status:
-//  *         - 200 if successful retrieval
-//  *         - 401 if signature mismatch or nonce mismatch
-//  *         - 404 if username or proof not found
-//  *         - 500 if db fails or other unknown issue
-//  */
-// #[get("/params/<oid>")]
-// pub async fn get_proof_with_params(
-//     user: AuthenticatedUser,
-//     oid: String,
-//     db: &State<GrapevineDB>,
-// ) -> Result<Json<ProvingData>, GrapevineResponse> {
-//     let oid = ObjectId::from_str(&oid).unwrap();
-//     match db.get_proof_and_data(user.0, oid).await {
-//         Some(data) => Ok(Json(data)),
-//         None => Err(GrapevineResponse::NotFound(format!(
-//             "No proof found with oid {}",
-//             oid
-//         ))),
-//     }
-// }
+/**
+ * Returns all the information needed to construct a proof of degree of separation from a given user
+ *
+ * @param oid - the ObjectID of the proof to retrieve
+ * @param username - the username to retrieve encrypted auth signature for when proving relationship
+ * @return - a ProvingData struct containing:
+ *         * degree: the separation degree of the returned proof
+ *         * proof: the gzip-compressed fold proof
+ *         * username: the username of the proof creator
+ *         * ephemeral_key: the ephemeral pubkey that can be combined with the requesting user's
+ *           private key to derive returned proof creator's auth signature decryption key
+ *         * ciphertext: the encrypted auth signature
+ * @return status:
+ *         - 200 if successful retrieval
+ *         - 401 if signature mismatch or nonce mismatch
+ *         - 404 if username or proof not found
+ *         - 500 if db fails or other unknown issue
+ */
+#[get("/params/<oid>")]
+pub async fn get_proof_with_params(
+    user: AuthenticatedUser,
+    oid: String,
+    db: &State<GrapevineDB>,
+) -> Result<Json<ProvingData>, GrapevineResponse> {
+    let oid = ObjectId::from_str(&oid).unwrap();
+    match db.get_proof_and_data(user.0, oid).await {
+        Some(data) => Ok(Json(data)),
+        None => Err(GrapevineResponse::NotFound(format!(
+            "No proof found with oid {}",
+            oid
+        ))),
+    }
+}
 
 // /**
 //  * Get all created phrases

--- a/crates/grapevine_server/src/routes/proof.rs
+++ b/crates/grapevine_server/src/routes/proof.rs
@@ -450,26 +450,26 @@ pub async fn prove_identity(
 
 // /// GET REQUESTS ///
 
-// /**
-//  * Return a list of all available (new) degree proofs from existing connections that a user can
-//  * build from
-//  *
-//  * @param username - the username to look up the available proofs for
-//  * @return - a vector of stringified OIDs of available proofs to use with get_proof_with_params
-//  *           route (empty if none)
-//  * @return status:
-//  *         - 200 if successful retrieval
-//  *         - 401 if signature mismatch or nonce mismatch
-//  *         - 404 if user not found
-//  *         - 500 if db fails or other unknown issue
-//  */
-// #[get("/available")]
-// pub async fn get_available_proofs(
-//     user: AuthenticatedUser,
-//     db: &State<GrapevineDB>,
-// ) -> Result<Json<Vec<String>>, Status> {
-//     Ok(Json(db.find_available_degrees(user.0).await))
-// }
+/**
+ * Return a list of all available (new) degree proofs from existing connections that a user can
+ * build from
+ *
+ * @param username - the username to look up the available proofs for
+ * @return - a vector of stringified OIDs of available proofs to use with get_proof_with_params
+ *           route (empty if none)
+ * @return status:
+ *         - 200 if successful retrieval
+ *         - 401 if signature mismatch or nonce mismatch
+ *         - 404 if user not found
+ *         - 500 if db fails or other unknown issue
+ */
+#[get("/available")]
+pub async fn get_available_proofs(
+    user: AuthenticatedUser,
+    db: &State<GrapevineDB>,
+) -> Result<Json<Vec<String>>, Status> {
+    Ok(Json(db.find_available_degrees(user.0).await))
+}
 
 // /**
 //  * Returns all the information needed to construct a proof of degree of separation from a given user

--- a/crates/grapevine_server/src/routes/proof.rs
+++ b/crates/grapevine_server/src/routes/proof.rs
@@ -3,6 +3,7 @@ use crate::mongo::GrapevineDB;
 use crate::utils::PUBLIC_PARAMS;
 use crate::{catchers::GrapevineResponse, guards::AuthenticatedUser};
 use grapevine_circuits::{nova::verify_grapevine_proof, utils::decompress_proof, inputs::GrapevineOutputs};
+use grapevine_common::models::AvailableProofs;
 use grapevine_common::{
     Fr, MAX_USERNAME_CHARS,
     http::{
@@ -467,7 +468,7 @@ pub async fn prove_identity(
 pub async fn get_available_proofs(
     user: AuthenticatedUser,
     db: &State<GrapevineDB>,
-) -> Result<Json<Vec<String>>, Status> {
+) -> Result<Json<Vec<AvailableProofs>>, Status> {
     Ok(Json(db.find_available_degrees(user.0).await))
 }
 


### PR DESCRIPTION
 - Fixed getting available proofs (no more proofs array in the user doc, just search using known fields)
 - Updated getting proof data:
     - Aggregation pipeline gets all necessary data in one HTTP call instead of three separate calls
     - Now gets new auth secret (signature and nullifier) exchanged in relationship formation
 - Uses new proof, auth secret, etc retrieved from server to prove next fold on client
 - Degree Proof route updated:
     - Retrieve all data needed for validation of call in one agg pipeline rather than many HTTP calls
     - Verify all expected outputs of the proof
     - Does NOT deactivate old proofs with dependent proceeding proofs/ remove old proofs with no dependent proceeding
     - Does NOT prevent proofs from being added if nullifier is already emitted
 - Unit test the absolute basic case of adding a degree 1 proof from an identity proof
     - Add deeper tests/ reorg/ edge cases in later PR when other relationship/ auth secret stuff is cleaned up
 
 