### PR TITLE
Fix/auth secret refactor

### DIFF
--- a/crates/grapevine_circuits/src/inputs.rs
+++ b/crates/grapevine_circuits/src/inputs.rs
@@ -3,7 +3,7 @@ use ff_ce::PrimeField;
 use grapevine_common::compat::{convert_ff_to_ff_ce, ff_ce_from_le_bytes, ff_ce_to_le_bytes};
 use grapevine_common::crypto::pubkey_to_address;
 use grapevine_common::utils::random_fr_ce;
-use grapevine_common::{auth_signature, Fr, Params};
+use grapevine_common::{Fr, Params};
 use nova_scotia::circom::circuit::R1CS;
 use num_bigint::{BigInt, Sign};
 use serde_json::{json, Value};

--- a/crates/grapevine_circuits/src/utils.rs
+++ b/crates/grapevine_circuits/src/utils.rs
@@ -1,16 +1,9 @@
-use crate::ZERO;
-use babyjubjub_rs::{new_key, Point, Signature};
-use ff_ce::PrimeField;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use grapevine_common::compat::{convert_ff_ce_to_ff, convert_ff_to_ff_ce, ff_ce_from_le_bytes};
-use grapevine_common::utils::{convert_phrase_to_fr, convert_username_to_fr, random_fr};
-use grapevine_common::{auth_signature, Fr, NovaProof, Params};
-use num_bigint::{BigInt, Sign};
-use serde_json::{json, Value};
+use grapevine_common::{NovaProof, Params};
+use std::env::current_dir;
 use std::io::{Read, Write};
-use std::{collections::HashMap, env::current_dir};
 
 /**
  * Read in a previously computed public params file
@@ -88,23 +81,4 @@ pub fn decompress_proof(proof: &[u8]) -> NovaProof {
     decoder.read_to_string(&mut serialized).unwrap();
     // deserialize the proof
     serde_json::from_str(&serialized).unwrap()
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_phrase_to_fr() {
-        let phrase = String::from("And that's the waaaayyy the news goes");
-        let bytes = convert_phrase_to_fr(&phrase);
-        println!("Phrase bytes {:?}", bytes);
-    }
-
-    #[test]
-    fn test_username_to_fr() {
-        let username = String::from("Chad Chadson");
-        let bytes = convert_username_to_fr(&username);
-        println!("User bytes {:?}", bytes);
-    }
 }

--- a/crates/grapevine_common/src/errors.rs
+++ b/crates/grapevine_common/src/errors.rs
@@ -10,6 +10,7 @@ pub enum GrapevineError {
     PubkeyExists(String),
     UserExists(String),
     PhraseTooLong,
+    NoRelationship(String, String),
     NoPendingRelationship(String, String),
     PendingRelationshipExists(String, String),
     ActiveRelationshipExists(String, String),
@@ -67,6 +68,13 @@ impl std::fmt::Display for GrapevineError {
                 write!(
                     f,
                     "No pending relationship exists from {} to {}",
+                    sender, recipient
+                )
+            },
+            GrapevineError::NoRelationship(sender, recipient) => {
+                write!(
+                    f,
+                    "No relationship exists from {} to {}",
                     sender, recipient
                 )
             }

--- a/crates/grapevine_common/src/http/requests.rs
+++ b/crates/grapevine_common/src/http/requests.rs
@@ -31,15 +31,15 @@ pub struct TestProofCompressionRequest {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct NewRelationshipRequest {
-    #[serde(with = "serde_bytes")]
-    pub encrypted_nullifier: [u8; 48],
-    #[serde(with = "serde_bytes")]
-    pub encrypted_nullifier_secret: [u8; 48],
     pub to: String,
     #[serde(with = "serde_bytes")]
     pub ephemeral_key: [u8; 32],
     #[serde(with = "serde_bytes")]
-    pub encrypted_auth_signature: [u8; 80],
+    pub signature_ciphertext: [u8; 80],
+    #[serde(with = "serde_bytes")]
+    pub nullifier_ciphertext: [u8; 48],
+    #[serde(with = "serde_bytes")]
+    pub nullifier_secret_ciphertext: [u8; 48],
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/grapevine_common/src/lib.rs
+++ b/crates/grapevine_common/src/lib.rs
@@ -2,7 +2,7 @@ use nova_scotia::{circom::circuit::CircomCircuit, C1, C2, F};
 use nova_snark::{provider, traits::circuit::TrivialTestCircuit, PublicParams, RecursiveSNARK};
 
 pub mod account;
-pub mod auth_signature;
+pub mod auth_secret;
 pub mod compat;
 pub mod crypto;
 pub mod errors;

--- a/crates/grapevine_common/src/models.rs
+++ b/crates/grapevine_common/src/models.rs
@@ -55,19 +55,19 @@ pub struct ProvingData {
 pub struct Relationship {
     #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
     pub id: Option<ObjectId>,
-    pub recipient: Option<ObjectId>, // use this privkey to decrypt
-    pub sender: Option<ObjectId>,
-    #[serde(default, with = "serde_bytes")]
-    pub encrypted_nullifier: Option<[u8; 48]>,
-    #[serde(default, with = "serde_bytes")]
-    pub encrypted_nullifier_secret: Option<[u8; 48]>,
-    #[serde(default, with = "serde_bytes")]
-    pub ephemeral_key: Option<[u8; 32]>,
-    #[serde(default, with = "serde_bytes")]
-    pub encrypted_auth_signature: Option<[u8; 80]>,
-    #[serde(default, with = "serde_bytes")]
-    pub emitted_nullifier: Option<[u8; 32]>,
     pub active: Option<bool>, // true if both users have accepted, false if pending
+    pub sender: Option<ObjectId>,
+    pub recipient: Option<ObjectId>,
+    #[serde(default, with = "serde_bytes")]
+    pub ephemeral_key: Option<[u8; 32]>, // pubkey + recipient privkey decrypts auth secret
+    #[serde(default, with = "serde_bytes")]
+    pub emitted_nullifier: Option<[u8; 32]>, // if Some, then relationship is nullified
+    #[serde(default, with = "serde_bytes")]
+    pub signature_ciphertext: Option<[u8; 80]>, // decryptable by recipient for proving
+    #[serde(default, with = "serde_bytes")]
+    pub nullifier_ciphertext: Option<[u8; 48]>, // decryptable by recipient for proving
+    #[serde(default, with = "serde_bytes")]
+    pub nullifier_secret_ciphertext: Option<[u8; 48]>, // decryptable by sender for nullifier emission
 }
 
 // All fields optional to allow projections

--- a/crates/grapevine_server/src/main.rs
+++ b/crates/grapevine_server/src/main.rs
@@ -58,7 +58,7 @@ mod test_rocket {
     };
     use grapevine_common::{
         account::GrapevineAccount,
-        auth_signature::AuthSignatureEncrypted,
+        auth_secret::AuthSignatureEncrypted,
         compat::ff_ce_to_le_bytes,
         http::{
             requests::{
@@ -601,7 +601,7 @@ mod test_rocket {
             inputs::{GrapevineInputs, GrapevineOutputs},
             nova::{degree_proof, verify_grapevine_proof},
         };
-        use grapevine_common::{auth_signature::AuthSignatureEncryptedUser, Fr};
+        use grapevine_common::{auth_secret::AuthSignatureEncryptedUser, Fr};
 
         use super::*;
         use crate::test_rocket::test_helper::*;

--- a/crates/grapevine_server/src/main.rs
+++ b/crates/grapevine_server/src/main.rs
@@ -539,32 +539,38 @@ mod test_rocket {
             assert_eq!(expected_secret, empirical_secret);
         }
 
+        #[ignore]
         #[rocket::async_test]
         pub async fn test_reject_relationship() {
             todo!("Unimplemented")
         }
 
+        #[ignore]
         #[rocket::async_test]
         pub async fn test_no_relationship_with_self() {
             todo!("Unimplemented")
         }
 
+        #[ignore]
         #[rocket::async_test]
         pub async fn test_cannot_reject_active_relationship() {
             // nullifiy, don't reject
             todo!("Unimplemented")
         }
 
+        #[ignore]
         #[rocket::async_test]
         pub async fn test_cannot_reject_nonexistent_relationship() {
             todo!("Unimplemented")
         }
 
+        #[ignore]
         #[rocket::async_test]
         pub async fn test_cannot_act_nullified_relationship() {
             todo!("Unimplemented")
         }
 
+        #[ignore]
         #[rocket::async_test]
         pub async fn test_cannot_request_already_active_relationship() {
             todo!("Unimplemented")
@@ -624,16 +630,19 @@ mod test_rocket {
             );
         }
 
+        #[ignore]
         #[rocket::async_test]
         pub async fn test_cannot_nullify_pending_relationship() {
             todo!("Unimplemented")
         }
 
+        #[ignore]
         #[rocket::async_test]
         pub async fn test_cannot_nullify_nullified_relationship() {
             todo!("Unimplemented")
         }
 
+        #[ignore]
         #[rocket::async_test]
         pub async fn test_cannot_nullify_nonexistent_relationship() {
             todo!("Unimplemented")

--- a/crates/grapevine_server/src/main.rs
+++ b/crates/grapevine_server/src/main.rs
@@ -58,7 +58,7 @@ mod test_rocket {
     };
     use grapevine_common::{
         account::GrapevineAccount,
-        auth_secret::AuthSignatureEncrypted,
+        auth_secret::AuthSecretEncrypted,
         compat::ff_ce_to_le_bytes,
         http::{
             requests::{
@@ -509,9 +509,9 @@ mod test_rocket {
             let context = GrapevineTestContext::init().await;
             GrapevineDB::drop("grapevine_mocked").await;
             // Create a request where proof creator is different from asserted pubkey
-            let mut user_a = GrapevineAccount::new("User_Coolaid".into());
+            let mut user_a = GrapevineAccount::new("user_a".into());
 
-            let mut user_b = GrapevineAccount::new("User_Oj".into());
+            let mut user_b = GrapevineAccount::new("user_b".into());
 
             let user_request_a = build_create_user_request(&user_a);
             let user_request_b = build_create_user_request(&user_b);
@@ -519,34 +519,66 @@ mod test_rocket {
             http_create_user(&context, &user_request_b).await;
 
             // add relationship as user_a to user_b
-            let user_a_relationship_request =
+            let request =
                 user_a.new_relationship_request(user_b.username(), &user_b.pubkey());
 
-            http_add_relationship(&context, &mut user_a, &user_a_relationship_request).await;
+            http_add_relationship(&context, &mut user_a, &request).await;
 
             // accept relation from user_a as user_b
-            let user_b_relationship_request =
+            let request =
                 user_b.new_relationship_request(user_a.username(), &user_a.pubkey());
+            let expected_nullifier_secret_ciphertext = request.nullifier_secret_ciphertext;
+            http_add_relationship(&context, &mut user_b, &request).await;
 
-            http_add_relationship(&context, &mut user_b, &user_b_relationship_request).await;
-
-            let encrypted_nullifier_secret =
+            // check stored nullifier secret integrity
+            let nullifier_secret_ciphertext =
                 http_get_nullifier_secret(&context, &mut user_b, user_a.username()).await;
-
-            let decrypted_local = user_b
-                .decrypt_nullifier_secret(user_b_relationship_request.encrypted_nullifier_secret);
-            let decrypted_server = user_b.decrypt_nullifier_secret(encrypted_nullifier_secret);
-            assert_eq!(decrypted_local, decrypted_server);
+            let expected_secret = user_b
+                .decrypt_nullifier_secret(expected_nullifier_secret_ciphertext);
+            let empirical_secret = user_b.decrypt_nullifier_secret(nullifier_secret_ciphertext);
+            assert_eq!(expected_secret, empirical_secret);
         }
+
+        #[rocket::async_test]
+        pub async fn test_reject_relationship() {
+            todo!("Unimplemented")
+        }
+
+        #[rocket::async_test]
+        pub async fn test_no_relationship_with_self() {
+            todo!("Unimplemented")
+        }
+
+        #[rocket::async_test]
+        pub async fn test_cannot_reject_active_relationship() {
+            // nullifiy, don't reject
+            todo!("Unimplemented")
+        }
+
+        #[rocket::async_test]
+        pub async fn test_cannot_reject_nonexistent_relationship() {
+            todo!("Unimplemented")
+        }
+
+        #[rocket::async_test]
+        pub async fn test_cannot_act_nullified_relationship() {
+            todo!("Unimplemented")
+        }
+
+        #[rocket::async_test]
+        pub async fn test_cannot_request_already_active_relationship() {
+            todo!("Unimplemented")
+        }
+
 
         #[rocket::async_test]
         pub async fn test_nullifier_emission() {
             let context = GrapevineTestContext::init().await;
             GrapevineDB::drop("grapevine_mocked").await;
             // Create a request where proof creator is different from asserted pubkey
-            let mut user_a = GrapevineAccount::new("User_Wombat".into());
+            let mut user_a = GrapevineAccount::new("user_a".into());
 
-            let mut user_b = GrapevineAccount::new("User_SucklingPig".into());
+            let mut user_b = GrapevineAccount::new("user_b".into());
 
             let user_request_a = build_create_user_request(&user_a);
             let user_request_b = build_create_user_request(&user_b);
@@ -581,7 +613,7 @@ mod test_rocket {
                 user_b.username(),
             )
             .await;
-            assert!(code == 200, "Nullifier emission call failed.");
+            assert!(code == 200, "Expected HTTP:OK on nullifier emission");
 
             // confirm relationship now has emitted nullifier
             let relationship =
@@ -591,6 +623,22 @@ mod test_rocket {
                 "No nullifier emitted"
             );
         }
+
+        #[rocket::async_test]
+        pub async fn test_cannot_nullify_pending_relationship() {
+            todo!("Unimplemented")
+        }
+
+        #[rocket::async_test]
+        pub async fn test_cannot_nullify_nullified_relationship() {
+            todo!("Unimplemented")
+        }
+
+        #[rocket::async_test]
+        pub async fn test_cannot_nullify_nonexistent_relationship() {
+            todo!("Unimplemented")
+        }
+
     }
 
     #[cfg(test)]
@@ -601,7 +649,7 @@ mod test_rocket {
             inputs::{GrapevineInputs, GrapevineOutputs},
             nova::{degree_proof, verify_grapevine_proof},
         };
-        use grapevine_common::{auth_secret::AuthSignatureEncryptedUser, Fr};
+        use grapevine_common::Fr;
 
         use super::*;
         use crate::test_rocket::test_helper::*;
@@ -641,16 +689,14 @@ mod test_rocket {
                 .0;
             let outputs = GrapevineOutputs::try_from(res).unwrap();
             // decrypt the auth secret
-            let auth_secret_encrypted = AuthSignatureEncrypted {
-                username: "".into(),
-                recipient: user_b.pubkey().compress(),
+            let auth_secret_encrypted = AuthSecretEncrypted {
                 ephemeral_key: proving_data.ephemeral_key,
                 signature_ciphertext: proving_data.signature_ciphertext,
                 nullifier_ciphertext: proving_data.nullifier_ciphertext,
             };
             let auth_secret = auth_secret_encrypted.decrypt(user_b.private_key());
             // build the inputs for the degree proof
-            let auth_signature = decompress_signature(&auth_secret.auth_signature).unwrap();
+            let auth_signature = decompress_signature(&auth_secret.signature).unwrap();
             let relation_pubkey = decompress_point(proving_data.relation_pubkey).unwrap();
             let relation_nullifier = Fr::from_repr(auth_secret.nullifier).unwrap();
             let inputs = GrapevineInputs::degree_step(

--- a/crates/grapevine_server/src/mongo.rs
+++ b/crates/grapevine_server/src/mongo.rs
@@ -250,16 +250,16 @@ impl GrapevineDB {
     }
 
     /**
-     * Adds a pending relationship to the relationship collection
+     * Adds a relationship to the relationship collection
+     * @notice - can be pending or active depending on whether set by the doc passed in
      *
      * @param - relationship to add
      * @returns - empty result on success and error on failure
      */
-    pub async fn add_pending_relationship(
+    pub async fn add_relationship(
         &self,
         relationship: &Relationship,
     ) -> Result<(), GrapevineError> {
-        // create new relationship document
         match self.relationships.insert_one(relationship, None).await {
             Ok(_) => Ok(()),
             Err(e) => Err(GrapevineError::MongoError(e.to_string())),
@@ -267,115 +267,32 @@ impl GrapevineDB {
     }
 
     /**
-     * Sets pending relationship to be active (to -> from) and creates a new relationship (from -> to)
+     * Sets pending relationship document to be active
      *
-     * @param relationship - the relationship to activate
-     * @returns - the object id of the activated relationship
+     * @param sender - the sender of the relationship document
+     * @param recipient - the recipient of the relationship document
+     * @returns - () or error
      */
     pub async fn activate_relationship(
         &self,
-        from_relationship: &Relationship,
-        to_relationship: &Relationship,
+        sender: &ObjectId,
+        recipient: &ObjectId,
     ) -> Result<(), GrapevineError> {
-        let from_query = doc! {
-            "sender": from_relationship.sender.unwrap(),
-            "recipient": from_relationship.recipient.unwrap()
-        };
-
-        let to_query = doc! {
-            "sender": to_relationship.sender.unwrap(),
-            "recipient": to_relationship.recipient.unwrap()
-        };
-
-        let find_options = FindOneOptions::builder()
-            .projection(doc! {"_id": 1})
-            .build();
-
-        // retrived oid for "from" relationship
-        let from_oid: Bson = self
-            .relationships
-            .find_one(from_query, Some(find_options.clone()))
-            .await
-            .unwrap()
-            .unwrap()
-            .id
-            .unwrap()
-            .into();
-
-        let to_oid: Bson = self
-            .relationships
-            .find_one(to_query, Some(find_options))
-            .await
-            .unwrap()
-            .unwrap()
-            .id
-            .unwrap()
-            .into();
-
-        let from_update = doc! {
-            "$set": {
-                "active": true,
-                "encrypted_nullifier_secret": Bson::Binary(Binary {
-                    subtype: bson::spec::BinarySubtype::Generic,
-                    bytes: from_relationship.encrypted_nullifier_secret.unwrap().to_vec(),
-                })
-            }
-        };
-
-        let to_update = doc! {
-            "$set": {
-                "active": true,
-                "encrypted_auth_signature": Bson::Binary(Binary {
-                    subtype: bson::spec::BinarySubtype::Generic,
-                    bytes: to_relationship.encrypted_auth_signature.unwrap().to_vec(),
-                }),
-                "encrypted_nullifier": Bson::Binary(Binary {
-                    subtype: bson::spec::BinarySubtype::Generic,
-                    bytes: to_relationship.encrypted_nullifier.unwrap().to_vec(),
-                }),
-                "ephemeral_key": Bson::Binary(Binary {
-                    subtype: bson::spec::BinarySubtype::Generic,
-                    bytes: to_relationship.ephemeral_key.unwrap().to_vec(),
-                }),
-            }
-        };
-
-        // update "from" relationship
-        match self
-            .relationships
-            .update_one(doc! {"_id": from_oid.clone()}, from_update, None)
-            .await
-        {
-            Ok(_) => (),
-            Err(e) => return Err(GrapevineError::MongoError(e.to_string())),
-        };
-
-        // update "to" relationship
-        match self
-            .relationships
-            .update_one(doc! {"_id": to_oid.clone()}, to_update, None)
-            .await
-        {
-            Ok(_) => (),
-            Err(e) => return Err(GrapevineError::MongoError(e.to_string())),
-        };
-
-        // push the relationship to the sender's list of relationships
-        let query = doc! { "_id": from_relationship.sender.unwrap() };
-        let update = doc! { "$push": { "relationships": from_oid } };
-        match self.users.update_one(query, update, None).await {
-            Ok(_) => (),
-            Err(e) => return Err(GrapevineError::MongoError(e.to_string())),
+        // try to update the document
+        let filter = doc! { "sender": sender, "recipient": recipient, "active": false };
+        let update = doc! { "$set": { "active": true }};
+        let result = self.relationships.update_one(filter, update, None).await;
+        // check if successful
+        match result {
+            Ok(result) => match result.upserted_id {
+                Some(_) => Ok(()),
+                None => Err(GrapevineError::NoPendingRelationship(
+                    sender.to_hex(),
+                    recipient.to_hex(),
+                )),
+            },
+            Err(e) => Err(GrapevineError::MongoError(e.to_string())),
         }
-
-        // push the relationship to the recipients's list of relationships
-        let query = doc! { "_id": to_relationship.sender.unwrap() };
-        let update = doc! { "$push": { "relationships": to_oid } };
-        match self.users.update_one(query, update, None).await {
-            Ok(_) => (),
-            Err(e) => return Err(GrapevineError::MongoError(e.to_string())),
-        }
-        Ok(())
     }
 
     // /**
@@ -494,11 +411,11 @@ impl GrapevineDB {
             doc! {
                 "$facet": {
                     "sender": [
-                        { "$match": { "username": "user_a" } },
+                        { "$match": { "username": sender } },
                         { "$project": { "sender": "$_id" } }
                     ],
                     "recipient": [
-                        { "$match": { "username": "user_b" } },
+                        { "$match": { "username": recipient } },
                         { "$project": { "recipient": "$_id" } }
                     ]
                 }
@@ -535,7 +452,10 @@ impl GrapevineDB {
                 }
             }
         } else {
-            return Err(GrapevineError::NoRelationship(sender.clone(), recipient.clone()));
+            return Err(GrapevineError::NoRelationship(
+                sender.clone(),
+                recipient.clone(),
+            ));
         }
     }
 
@@ -746,49 +666,6 @@ impl GrapevineDB {
             Err(e) => Err(GrapevineError::MongoError(e.to_string())),
         }
     }
-
-    // /**
-    //  * Creates a new phrase document in the database
-    //  * @notice assumes that `get_phrase_by_{hash, oid}` has already been called
-    //  *
-    //  * @param phrase_hash - the hash of the phrase to create
-    //  * @param description - the description of the phrase
-    //  * @return: (0, 1)
-    //  *  - 0: the object id of the created phrase document
-    //  *  - 1: the index of the phrase
-    //  */
-    // pub async fn create_phrase(
-    //     &self,
-    //     phrase_hash: [u8; 32],
-    //     description: String,
-    // ) -> Result<(ObjectId, u32), GrapevineError> {
-    //     // query for the highest phrase id
-    //     let find_options = FindOneOptions::builder().sort(doc! {"index": -1}).build();
-
-    //     // Use find_one with options to get the document with the largest phrase_id
-    //     let index = match self.phrases.find_one(None, find_options).await {
-    //         Ok(Some(document)) => {
-    //             let previous_index = document.index.unwrap();
-    //             previous_index + 1
-    //         }
-    //         Ok(None) => 1,
-    //         Err(e) => return Err(GrapevineError::MongoError(e.to_string())),
-    //     };
-
-    //     // create new phrase document
-    //     let phrase = Phrase {
-    //         id: None,
-    //         index: Some(index),
-    //         hash: Some(phrase_hash),
-    //         description: Some(description),
-    //     };
-    //     let oid = match self.phrases.insert_one(&phrase, None).await {
-    //         Ok(res) => res.inserted_id.as_object_id().unwrap(),
-    //         Err(e) => return Err(GrapevineError::MongoError(e.to_string())),
-    //     };
-
-    //     Ok((oid, index))
-    // }
 
     /**
      * Adds an identity proof for a given user

--- a/crates/grapevine_server/src/routes/user.rs
+++ b/crates/grapevine_server/src/routes/user.rs
@@ -235,7 +235,9 @@ pub async fn add_relationship(
         id: None,
         sender: Some(sender.id.unwrap()),
         recipient: Some(recipient.id.unwrap()),
-        encrypted_nullifier_secret: Some(request.encrypted_nullifier_secret),
+        // @TODO
+        // encrypted_nullifier_secret: Some(request.encrypted_nullifier_secret),
+        encrypted_nullifier_secret: None,
         encrypted_nullifier: None,
         ephemeral_key: None,
         encrypted_auth_signature: None,
@@ -249,8 +251,11 @@ pub async fn add_relationship(
         recipient: Some(sender.id.unwrap()),
         encrypted_nullifier_secret: None,
         ephemeral_key: Some(request.ephemeral_key),
-        encrypted_auth_signature: Some(request.encrypted_auth_signature),
-        encrypted_nullifier: Some(request.encrypted_nullifier),
+        // @TODO
+        // encrypted_auth_signature: Some(request.encrypted_auth_signature),
+        encrypted_auth_signature: None,
+        // encrypted_nullifier: Some(request.encrypted_nullifier),
+        encrypted_nullifier: None,
         emitted_nullifier: None,
         active: Some(activate),
     };


### PR DESCRIPTION
Addresses #68 
 - Renames "AuthSignature" to be "AuthSecret" where AuthSecret = (Signature, Nullifier)
 - Refactors AuthSecret code: removes bloat & condenses functionality
 - Standardize naming in documents/ models
 - Update relationship add route:
     - Put nullifier secret, auth secret in the recipient's document where sender = caller
     - Only one relationship document created per relationship add call
     - Activating relationship simply = toggling a relationship to be active
  - Update degree proof data retrieval to work with new info
  - Unit tests refactored to be compatible 
     